### PR TITLE
[AI Worker] Create a CRUD todo list application

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,350 @@
+:root {
+  --color-sand: #f5efe4;
+  --color-paper: #fffdf8;
+  --color-ink: #1f2933;
+  --color-muted: #52606d;
+  --color-line: #d9cbb6;
+  --color-accent: #d66a3d;
+  --color-accent-dark: #9f4320;
+  --color-danger: #b42318;
+  --color-success: #17663b;
+  --shadow-soft: 0 18px 45px rgba(66, 41, 19, 0.12);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --space-1: 0.5rem;
+  --space-2: 0.75rem;
+  --space-3: 1rem;
+  --space-4: 1.5rem;
+  --space-5: 2rem;
+  --space-6: 3rem;
+  --font-display: "Avenir Next", "Segoe UI", sans-serif;
+  --font-body: "IBM Plex Sans", "Segoe UI", sans-serif;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: var(--font-body);
+  color: var(--color-ink);
+  background:
+    radial-gradient(circle at top left, rgba(214, 106, 61, 0.18), transparent 28%),
+    linear-gradient(180deg, #f7f2e7 0%, #efe5d4 100%);
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.app {
+  width: min(1120px, calc(100% - 2rem));
+  margin: 0 auto;
+  padding: 5rem 0 3rem;
+  display: grid;
+  gap: var(--space-4);
+}
+
+.app__panel,
+.todo-list {
+  background: rgba(255, 253, 248, 0.88);
+  border: 1px solid rgba(217, 203, 182, 0.8);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  backdrop-filter: blur(14px);
+}
+
+.app__panel {
+  padding: var(--space-5);
+}
+
+.app__header {
+  margin-bottom: var(--space-5);
+}
+
+.app__eyebrow {
+  margin: 0 0 var(--space-2);
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--color-accent-dark);
+}
+
+.app__title,
+.todo-form__title,
+.todo-list__title {
+  margin: 0;
+  font-family: var(--font-display);
+  line-height: 1.1;
+}
+
+.app__title {
+  font-size: clamp(2.3rem, 4vw, 4rem);
+  max-width: 12ch;
+}
+
+.app__intro,
+.todo-form__subtitle,
+.todo-list__subtitle,
+.todo-item__meta,
+.todo-item__description,
+.todo-list__empty {
+  color: var(--color-muted);
+}
+
+.app__intro {
+  max-width: 52ch;
+  margin: var(--space-3) 0 0;
+  font-size: 1rem;
+  line-height: 1.7;
+}
+
+.todo-form {
+  padding: var(--space-4);
+  border-radius: var(--radius-md);
+  background: var(--color-paper);
+  border: 1px solid var(--color-line);
+}
+
+.todo-form__heading {
+  margin-bottom: var(--space-4);
+}
+
+.todo-form__subtitle,
+.todo-list__subtitle {
+  margin: var(--space-1) 0 0;
+}
+
+.todo-form__field + .todo-form__field {
+  margin-top: var(--space-4);
+}
+
+.todo-form__label {
+  display: block;
+  margin-bottom: var(--space-2);
+  font-weight: 600;
+}
+
+.todo-form__input {
+  width: 100%;
+  padding: 0.95rem 1rem;
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.todo-form__input:focus {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 4px rgba(214, 106, 61, 0.16);
+}
+
+.todo-form__input--textarea {
+  min-height: 8rem;
+  resize: vertical;
+}
+
+.todo-form__actions {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.button {
+  border: 0;
+  border-radius: 999px;
+  padding: 0.8rem 1.2rem;
+  font-weight: 600;
+  transition: transform 160ms ease, opacity 160ms ease, background-color 160ms ease;
+}
+
+.button:hover,
+.button:focus-visible {
+  transform: translateY(-1px);
+}
+
+.button--primary {
+  background: var(--color-accent);
+  color: #fff;
+}
+
+.button--primary:hover,
+.button--primary:focus-visible {
+  background: var(--color-accent-dark);
+}
+
+.button--ghost {
+  background: rgba(31, 41, 51, 0.06);
+  color: var(--color-ink);
+}
+
+.button--danger {
+  background: rgba(180, 35, 24, 0.1);
+  color: var(--color-danger);
+}
+
+.todo-list {
+  padding: var(--space-5);
+}
+
+.todo-list__header {
+  margin-bottom: var(--space-4);
+}
+
+.todo-list__items {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: var(--space-3);
+}
+
+.todo-list__empty {
+  padding: var(--space-5);
+  text-align: center;
+  background: rgba(245, 239, 228, 0.7);
+  border: 1px dashed var(--color-line);
+  border-radius: var(--radius-md);
+}
+
+.todo-item {
+  padding: var(--space-4);
+  border: 1px solid var(--color-line);
+  border-radius: var(--radius-md);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.98) 0%, rgba(245, 239, 228, 0.9) 100%);
+  transition: transform 160ms ease, border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.todo-item:hover {
+  transform: translateY(-2px);
+  border-color: rgba(214, 106, 61, 0.45);
+  box-shadow: 0 12px 26px rgba(55, 32, 15, 0.1);
+}
+
+.todo-item__button {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  text-align: left;
+  background: transparent;
+  color: inherit;
+}
+
+.todo-item__top {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.todo-item__title {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.todo-item__meta {
+  margin: var(--space-2) 0 0;
+  font-size: 0.88rem;
+}
+
+.todo-item__description {
+  margin: var(--space-3) 0 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.todo-item__actions {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.toast-stack {
+  position: fixed;
+  top: 1rem;
+  left: 50%;
+  z-index: 10;
+  transform: translateX(-50%);
+  width: min(92vw, 440px);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.toast {
+  padding: 0.95rem 1rem;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  box-shadow: 0 14px 30px rgba(31, 41, 51, 0.2);
+  animation: toast-in 180ms ease;
+}
+
+.toast--success {
+  background: var(--color-success);
+}
+
+.toast--error {
+  background: var(--color-danger);
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (min-width: 860px) {
+  .app {
+    grid-template-columns: minmax(320px, 420px) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .app__panel {
+    position: sticky;
+    top: 2rem;
+  }
+}
+
+@media (max-width: 559px) {
+  .app {
+    width: min(100% - 1rem, 1120px);
+    padding-top: 4rem;
+  }
+
+  .app__panel,
+  .todo-list {
+    padding: var(--space-4);
+  }
+
+  .todo-item__top {
+    flex-direction: column;
+  }
+
+  .todo-item__actions,
+  .todo-form__actions {
+    flex-direction: column;
+  }
+
+  .button {
+    width: 100%;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Todo CRUD App</title>
+    <link rel="stylesheet" href="./css/style.css" />
+  </head>
+  <body>
+    <div class="toast-stack" id="toast-container" aria-live="polite" aria-atomic="true"></div>
+
+    <main class="app">
+      <section class="app__panel">
+        <header class="app__header">
+          <p class="app__eyebrow">Local Todo Manager</p>
+          <h1 class="app__title">Track tasks without leaving the browser.</h1>
+          <p class="app__intro">
+            Add, edit, and remove notes. Everything is stored in localStorage and survives refresh.
+          </p>
+        </header>
+
+        <section class="todo-form" aria-labelledby="todo-form-title">
+          <div class="todo-form__heading">
+            <h2 id="todo-form-title" class="todo-form__title">Add a todo</h2>
+            <p class="todo-form__subtitle" id="todo-form-mode-text">Create a new item.</p>
+          </div>
+
+          <form id="todo-form" novalidate>
+            <input type="hidden" id="todo-id" name="todo-id" />
+
+            <div class="todo-form__field">
+              <label class="todo-form__label" for="title">Title</label>
+              <input
+                class="todo-form__input"
+                id="title"
+                name="title"
+                type="text"
+                maxlength="80"
+                required
+                placeholder="Buy groceries"
+              />
+            </div>
+
+            <div class="todo-form__field">
+              <label class="todo-form__label" for="description">Description</label>
+              <textarea
+                class="todo-form__input todo-form__input--textarea"
+                id="description"
+                name="description"
+                rows="4"
+                maxlength="240"
+                placeholder="Add optional details"
+              ></textarea>
+            </div>
+
+            <div class="todo-form__actions">
+              <button class="button button--primary" id="submit-button" type="submit">Add</button>
+              <button class="button button--ghost" id="cancel-button" type="button" hidden>
+                Cancel
+              </button>
+            </div>
+          </form>
+        </section>
+      </section>
+
+      <section class="todo-list" aria-labelledby="todo-list-title">
+        <div class="todo-list__header">
+          <h2 id="todo-list-title" class="todo-list__title">Your todos</h2>
+          <p class="todo-list__subtitle">Tap any card to edit, or use the action buttons.</p>
+        </div>
+
+        <ul class="todo-list__items" id="todo-list-items"></ul>
+      </section>
+    </main>
+
+    <script type="module" src="./js/app.js"></script>
+  </body>
+</html>

--- a/js/app.js
+++ b/js/app.js
@@ -1,0 +1,104 @@
+import { addTodo, deleteTodo, getTodos, updateTodo } from "./store.js";
+import {
+  getCancelButton,
+  getFormElement,
+  getFormValues,
+  getListElement,
+  populateForm,
+  renderTodos,
+  resetForm,
+  showToast,
+} from "./ui.js";
+
+let editingTodoId = null;
+
+const syncView = () => {
+  renderTodos(getTodos());
+};
+
+const handleFormSubmit = (event) => {
+  event.preventDefault();
+
+  const { title, description } = getFormValues();
+  const trimmedTitle = title.trim();
+
+  if (!trimmedTitle) {
+    showToast("Title is required.", "error");
+    return;
+  }
+
+  if (editingTodoId) {
+    const updatedTodo = updateTodo(editingTodoId, { title, description });
+
+    if (!updatedTodo) {
+      showToast("Todo could not be updated.", "error");
+      return;
+    }
+
+    showToast("Todo updated.");
+  } else {
+    addTodo({ title, description });
+    showToast("Todo added.");
+  }
+
+  editingTodoId = null;
+  resetForm();
+  syncView();
+};
+
+const handleListClick = (event) => {
+  const actionButton = event.target.closest("[data-action]");
+
+  if (!actionButton) {
+    return;
+  }
+
+  const { action, id } = actionButton.dataset;
+
+  if (!id) {
+    return;
+  }
+
+  if (action === "delete") {
+    const wasDeleted = deleteTodo(id);
+
+    if (!wasDeleted) {
+      showToast("Todo could not be deleted.", "error");
+      return;
+    }
+
+    if (editingTodoId === id) {
+      editingTodoId = null;
+      resetForm();
+    }
+
+    syncView();
+    showToast("Todo deleted.");
+    return;
+  }
+
+  if (action === "edit") {
+    const todo = getTodos().find((item) => item.id === id);
+
+    if (!todo) {
+      showToast("Todo could not be found.", "error");
+      return;
+    }
+
+    editingTodoId = id;
+    populateForm(todo);
+  }
+};
+
+const initApp = () => {
+  syncView();
+
+  getFormElement().addEventListener("submit", handleFormSubmit);
+  getListElement().addEventListener("click", handleListClick);
+  getCancelButton().addEventListener("click", () => {
+    editingTodoId = null;
+    resetForm();
+  });
+};
+
+initApp();

--- a/js/store.js
+++ b/js/store.js
@@ -1,0 +1,80 @@
+const STORAGE_KEY = "todos";
+
+const createId = () => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+};
+
+export const getTodos = () => {
+  const storedValue = localStorage.getItem(STORAGE_KEY);
+
+  if (!storedValue) {
+    return [];
+  }
+
+  try {
+    const todos = JSON.parse(storedValue);
+    return Array.isArray(todos) ? todos : [];
+  } catch {
+    return [];
+  }
+};
+
+export const saveTodos = (todos) => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(todos));
+};
+
+export const addTodo = ({ title, description }) => {
+  const nextTodo = {
+    id: createId(),
+    title: title.trim(),
+    description: description.trim(),
+    createdAt: new Date().toISOString(),
+  };
+
+  const todos = getTodos();
+  const nextTodos = [nextTodo, ...todos];
+
+  saveTodos(nextTodos);
+
+  return nextTodo;
+};
+
+export const updateTodo = (id, updates) => {
+  const todos = getTodos();
+  let updatedTodo = null;
+
+  const nextTodos = todos.map((todo) => {
+    if (todo.id !== id) {
+      return todo;
+    }
+
+    updatedTodo = {
+      ...todo,
+      ...updates,
+      title: updates.title.trim(),
+      description: updates.description.trim(),
+    };
+
+    return updatedTodo;
+  });
+
+  saveTodos(nextTodos);
+
+  return updatedTodo;
+};
+
+export const deleteTodo = (id) => {
+  const todos = getTodos();
+  const nextTodos = todos.filter((todo) => todo.id !== id);
+  const wasDeleted = nextTodos.length !== todos.length;
+
+  if (wasDeleted) {
+    saveTodos(nextTodos);
+  }
+
+  return wasDeleted;
+};

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,104 @@
+const form = document.querySelector("#todo-form");
+const titleInput = document.querySelector("#title");
+const descriptionInput = document.querySelector("#description");
+const todoIdInput = document.querySelector("#todo-id");
+const submitButton = document.querySelector("#submit-button");
+const cancelButton = document.querySelector("#cancel-button");
+const formTitle = document.querySelector("#todo-form-title");
+const formModeText = document.querySelector("#todo-form-mode-text");
+const listElement = document.querySelector("#todo-list-items");
+const toastContainer = document.querySelector("#toast-container");
+
+const formatDate = (value) =>
+  new Intl.DateTimeFormat("en", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }).format(new Date(value));
+
+const escapeHtml = (value) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+
+export const renderTodos = (todos) => {
+  if (todos.length === 0) {
+    listElement.innerHTML = '<li class="todo-list__empty">No todos yet. Start with the form.</li>';
+    return;
+  }
+
+  listElement.innerHTML = todos
+    .map(
+      ({ id, title, description, createdAt }) => `
+        <li class="todo-item" data-id="${id}">
+          <button class="todo-item__button" type="button" data-action="edit" data-id="${id}">
+            <div class="todo-item__top">
+              <div>
+                <h3 class="todo-item__title">${escapeHtml(title)}</h3>
+                <p class="todo-item__meta">Created ${formatDate(createdAt)}</p>
+              </div>
+            </div>
+            <p class="todo-item__description">${
+              description ? escapeHtml(description) : "No description provided."
+            }</p>
+          </button>
+          <div class="todo-item__actions">
+            <button class="button button--ghost" type="button" data-action="edit" data-id="${id}">
+              Edit
+            </button>
+            <button class="button button--danger" type="button" data-action="delete" data-id="${id}">
+              Delete
+            </button>
+          </div>
+        </li>
+      `,
+    )
+    .join("");
+};
+
+export const populateForm = (todo) => {
+  todoIdInput.value = todo.id;
+  titleInput.value = todo.title;
+  descriptionInput.value = todo.description;
+  submitButton.textContent = "Update";
+  cancelButton.hidden = false;
+  formTitle.textContent = "Edit todo";
+  formModeText.textContent = "Update the selected item.";
+  titleInput.focus();
+};
+
+export const resetForm = () => {
+  form.reset();
+  todoIdInput.value = "";
+  submitButton.textContent = "Add";
+  cancelButton.hidden = true;
+  formTitle.textContent = "Add a todo";
+  formModeText.textContent = "Create a new item.";
+};
+
+export const showToast = (message, type = "success") => {
+  const toast = document.createElement("div");
+  toast.className = `toast toast--${type}`;
+  toast.textContent = message;
+
+  toastContainer.appendChild(toast);
+
+  window.setTimeout(() => {
+    toast.remove();
+  }, 3000);
+};
+
+export const getFormValues = () => ({
+  id: todoIdInput.value,
+  title: titleInput.value,
+  description: descriptionInput.value,
+});
+
+export const getListElement = () => listElement;
+
+export const getFormElement = () => form;
+
+export const getCancelButton = () => cancelButton;


### PR DESCRIPTION
## Summary

This PR was generated automatically by AI Worker for issue #1.

### Plan

## AI Worker Plan

**Issue:** #1 — Create a CRUD todo list application

### Understanding
This issue requires building the full todo app from scratch in this repository using only vanilla HTML, CSS, and ES6 modules. The implementation needs to follow [agent.md](/Users/huahua/autotask/frontend-crud-demo/agent.md), put styles in [css/style.css](/Users/huahua/autotask/frontend-crud-demo/css/style.css), use [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js) for localStorage access, [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js) for DOM updates, and [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js) as the main entry point.

### Proposed Steps
1. Create [index.html](/Users/huahua/autotask/frontend-crud-demo/index.html) with semantic HTML5 sections that match the documented component structure: a toast container at the top, a single todo form inside `<main>` for both create/edit, and a `<ul>`-based item list. Add the exact module entry point `<script type="module" src="./js/app.js"></script>`, and structure markup so `renderTodos(todos)` in [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js) can populate `<li>` items containing title, description, created date, and `Edit` / `Delete` buttons as required by [docs/components.md](/Users/huahua/autotask/frontend-crud-demo/docs/components.md).

2. Add [css/style.css](/Users/huahua/autotask/frontend-crud-demo/css/style.css) using the documented patterns from [docs/coding-style.md](/Users/huahua/autotask/frontend-crud-demo/docs/coding-style.md): CSS custom properties for colors and spacing, mobile-first layout rules, and BEM class names for the form, list, item, and toast blocks. Style the single create/edit form state so the submit button text can visually support `"Add"` vs `"Update"`, include a visible cancel button state, and ensure the list layout collapses cleanly for mobile while keeping desktop spacing readable.

3. Implement [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js) with localStorage CRUD functions using ES6 module exports, following the repository rule that all persistence lives in this file: `export const getTodos = () => {}`, `export const saveTodos = (todos) => {}`, `export const addTodo = ({ title, description }) => {}`, `export const updateTodo = (id, updates) => {}`, and `export const deleteTodo = (id) => {}`. Use a single storage key constant such as `const STORAGE_KEY = 'todos'`, store each todo with specific fields `{ id, title, description, createdAt }`, generate `createdAt` during creation for the list display pattern in [docs/components.md](/Users/huahua/autotask/frontend-crud-demo/docs/components.md), and make `title` required while allowing an empty description.

4. Implement [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js) for all DOM rendering and form-mode updates, matching the documented separation of concerns and event-delegation rule from [docs/coding-style.md](/Users/huahua/autotask/frontend-crud-demo/docs/coding-style.md). Add exact exported functions `export const renderTodos = (todos) => {}`, `export const populateForm = (todo) => {}`, `export const resetForm = () => {}`, and `export const showToast = (message, type = 'success') => {}`; make `renderTodos(todos)` output `<ul>` / `<li>` items with created-date text and `data-id` hooks for delegated edit/delete handling, and make `showToast()` auto-dismiss after `3000` ms per [docs/components.md](/Users/huahua/autotask/frontend-crud-demo/docs/components.md).

5. Implement [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js) as the application controller and ES6 module entry point, with exact functions `const initApp = () => {}`, `const handleFormSubmit = (event) => {}`, and `const handleListClick = (event) => {}`. Follow the repo’s prescribed pattern by importing store methods from [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js) and DOM helpers from [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js), using a single form for create/edit with an `editingTodoId` state variable, switching submit button text between `"Add"` and `"Update"`, wiring a cancel action to `resetForm()`, and attaching one delegated click listener to the parent list container instead of per-item listeners.

6. Verify the behavior through a manual CRUD flow against the implemented files: in [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js), confirm `addTodo({ title: 'Buy milk', description: '2 liters' })` persists to localStorage; in [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js), confirm clicking an item’s edit control loads its values into the shared form and `handleFormSubmit(event)` updates the same `id`; and confirm deleting removes the item from both the DOM rendered by `renderTodos(todos)` in [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js) and the `todos` entry under the chosen localStorage key after refresh.

### Risks / Notes
- The repository currently contains only documentation, so [index.html](/Users/huahua/autotask/frontend-crud-demo/index.html), [css/style.css](/Users/huahua/autotask/frontend-crud-demo/css/style.css), [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js), [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js), and [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js) will all need to be created from scratch.
- Because edit mode uses a single shared form, the main edge case is avoiding accidental creation of a duplicate item when the user intended to update an existing `id`.
- `localStorage` data can be malformed or missing; `getTodos()` should defensively fall back to an empty array so the app still renders after refresh.

---
Reply with one of:
- `approve` — proceed with execution
- `skip` — ignore this issue
- `revise: <feedback>` — revise the plan with your feedback

### Codex Output (stdout)

```
Implemented the vanilla CRUD todo app from scratch with the documented split across [index.html](/Users/huahua/autotask/frontend-crud-demo/index.html), [css/style.css](/Users/huahua/autotask/frontend-crud-demo/css/style.css), [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js), [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js), and [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js).

The app now supports create/read/update/delete with a single shared form, delegated list actions, toast notifications, responsive mobile-first styling, and `localStorage` persistence. Storage logic is isolated in [js/store.js](/Users/huahua/autotask/frontend-crud-demo/js/store.js), DOM rendering and form-state helpers are in [js/ui.js](/Users/huahua/autotask/frontend-crud-demo/js/ui.js), and the controller wiring lives in [js/app.js](/Users/huahua/autotask/frontend-crud-demo/js/app.js).

Verification: `node --check js/store.js && node --check js/ui.js && node --check js/app.js` passed. I did not run an in-browser manual test here, so the remaining check is opening [index.html](/Users/huahua/autotask/frontend-crud-demo/index.html) in a browser and confirming the full CRUD flow against `localStorage`.

```

Closes #1
